### PR TITLE
Made the detection of the start date of forcing files automatic.

### DIFF
--- a/ANT50.GL1-ISMIP6_elmer.sif
+++ b/ANT50.GL1-ISMIP6_elmer.sif
@@ -271,7 +271,11 @@ End
 !#                
 !#     - comments : * if no asmb required for the simulation, simply desactivate it
 !#                    in Exec Solver using Never keyword (pre-written line) and switching comment in body_force
-!#                  * offset is automatically managed by run_param.bash and prepare_elmer.bash (need user input)
+!#                  * offset is managed by run_param.bash and prepare_elmer.bash. By default, it is calculated
+!#                    automatically by prepare_elmer.bash from the forcing file start date and the simulation
+!#                    start date, although users can override the value of the forcing file start date by
+!#                    defining it explicitly in run_param.bash.
+!#                    NB: same comment for offset of ocean forcing file below.
 !#-----------------------------------------------------------------------
 Solver 5
    Exec Solver = Before simulation

--- a/prepare_elmer.bash
+++ b/prepare_elmer.bash
@@ -24,6 +24,23 @@ if [ ! -d SELMER  ]; then mkdir -p  $SELMER   ; fi
 # to fix issue for vtu group gidbit
 chgrp -R ${GROUPUSR} ${WELMER}
 
+# Calculate time offsets of forcing files
+function value_from_incf_file {
+    # Print value (from incf file) of variable given as argument.
+    echo $(grep -E "^[ \t]*\\\$$1[ \t]*=" $CONFIG-${CASE}_elmer.incf | cut -d= -f2 | cut -d! -f1 | cut -d\" -f2)
+}
+function start_year_of_netcdf_file {
+    # Print year of first time frame in netcdf file (given the name of the file in incf file).
+    typeset filepath=$(value_from_incf_file data_dir)/$(value_from_incf_file $1)
+    # For now, we rely on the netcdf file having a properly defined time
+    # variable. Other methods can be implemented later on a need basis
+    echo $(ncdump -t -v time $filepath | grep -E "^ time = \"" | cut -d\" -f2 | cut -d- -f1)
+}
+[ -z ${START_YEAR_FORCING+x} ] && START_YEAR_FORCING=$(start_year_of_netcdf_file file_asmb)
+[ -z ${START_YEAR_FORCING_OC+x} ] && START_YEAR_FORCING_OC=$(start_year_of_netcdf_file file_pico)
+OFFSET=$((START_SIMU-START_YEAR_FORCING))
+OFFSETOC=$((START_SIMU-START_YEAR_FORCING_OC))
+
 # set symbolic link
 if [ ! -L MY_WORK    ]; then ln -s $WELMER MY_WORK    ; fi
 if [ ! -L MY_RESTART ]; then ln -s $RELMER MY_RESTART ; fi

--- a/prepare_elmer.bash
+++ b/prepare_elmer.bash
@@ -34,10 +34,17 @@ function start_year_of_netcdf_file {
     typeset filepath=$(value_from_incf_file data_dir)/$(value_from_incf_file $1)
     # For now, we rely on the netcdf file having a properly defined time
     # variable. Other methods can be implemented later on a need basis
-    echo $(ncdump -t -v time $filepath | grep -E "^ time = \"" | cut -d\" -f2 | cut -d- -f1)
+    typeset ncdata=$(ncdump -t -v time $filepath)
+    if [ $? != 0 ] ; then
+        echo "-999"
+    else
+        echo "$ncdata" | grep -E "^ time = \"" | cut -d\" -f2 | cut -d- -f1
+    fi
 }
 [ -z ${START_YEAR_FORCING+x} ] && START_YEAR_FORCING=$(start_year_of_netcdf_file file_asmb)
 [ -z ${START_YEAR_FORCING_OC+x} ] && START_YEAR_FORCING_OC=$(start_year_of_netcdf_file file_pico)
+[ $START_YEAR_FORCING = -999 ] && echo "Problem with start date of atmospheric forcing file. Exiting..." && exit -2
+[ $START_YEAR_FORCING_OC = -999 ] && echo "Problem with start date of oceanic forcing file. Exiting..." && exit -2
 OFFSET=$((START_SIMU-START_YEAR_FORCING))
 OFFSETOC=$((START_SIMU-START_YEAR_FORCING_OC))
 

--- a/run_param.bash
+++ b/run_param.bash
@@ -27,14 +27,13 @@ TIME_RST=`calc $NSTEP*$TIME_STP` # in days
 #------------------------------------------------------------------------------
 #                               FORCING DATA
 #------------------------------------------------------------------------------
-# first year in atmospheric forcing file / first year to read in the simulation 
-START_YEAR_FORCING=1995    
 START_SIMU=2015
-OFFSET=$((START_SIMU-START_YEAR_FORCING))
-
-# first year in oceanic forcing file / first year to read in the simulation
-START_YEAR_FORCING_OC=1995
-OFFSETOC=$((START_SIMU-START_YEAR_FORCING_OC))
+# The starting year of forcing files is detected automatically by
+# prepare_elmer.bash. To override this automatic detection, you can set one or
+# both of the following variables (for the atmospheric and oceanic forcing
+# files, respectively)
+# START_YEAR_FORCING=1995
+# START_YEAR_FORCING_OC=1995
 
 #------------------------------------------------------------------------------
 #                               RESTART DATA


### PR DESCRIPTION
NB: I wrote the code as succinctly as possible. It does not check all the things that can possibly go wrong (e.g. netcdf file missing, ncdump not found). It assumes that users know what they are doing. After a simulation, users can check the values that have been used to replace OFFSET and OFFSETOC in Elmer/Ice's main sif file.